### PR TITLE
Bundle hints with well-formedness proof

### DIFF
--- a/ZKProof/Plonkish/CheckHints.lean
+++ b/ZKProof/Plonkish/CheckHints.lean
@@ -1,0 +1,189 @@
+import Mathlib.Tactic
+
+import ZKProof.Plonkish.Defs
+
+/-!
+# Hints well-formedness (`check_hints`)
+
+Issue #65: hints have a condition to satisfy: two hints can only map
+to the same concrete column and offset if the source cells are
+semantically the same.
+
+The hints map each abstract column `i` to `(h_i, e_i)` where:
+- `h_i` is a target concrete column index
+- `e_i` is a row offset
+
+When two abstract columns `i, k` get the same `(h_i, e_i) = (h_k, e_k)`,
+cells `(i, j)` and `(k, j)` are "column-and-offset identified" in the
+concrete circuit (they both become `(h_i, r(j) + e_i)` for any valid
+row mapping `r`).  For this identification to be harmless, the cells
+must be semantically the same.
+
+## Semantic sameness
+
+Per the issue:
+- **Fixed columns**: the values are identical (`f(i, j) = f(k, j)`)
+- **Non-fixed columns**: the cells are equated by `≡` OR both are
+  unconstrained (so arbitrary values are fine)
+
+## The `check_hints` predicate
+
+We formalize this as a `Prop`-valued predicate.  A circuit's hints
+are well-formed iff for every pair of columns identified by the hints,
+every row witnesses semantic sameness.
+-/
+
+variable {F : Type} [Field F]
+
+namespace CheckHints
+
+/-- Hints mapping abstract columns to (target column, row offset). -/
+structure Hints (G : Geometry) where
+  /-- Target concrete column index for each abstract column. -/
+  h : G.Col → ℕ
+  /-- Row offset for each abstract column. -/
+  e : G.Col → ℤ
+
+/-- Two hints are "column-and-offset identified": they point to the
+    same concrete column with the same offset. -/
+def Identified {G : Geometry} (hints : Hints G) (i k : G.Col) : Prop :=
+  hints.h i = hints.h k ∧ hints.e i = hints.e k
+
+theorem Identified.refl {G : Geometry} (hints : Hints G) (i : G.Col) :
+    Identified hints i i :=
+  ⟨rfl, rfl⟩
+
+theorem Identified.symm {G : Geometry} {hints : Hints G} {i k : G.Col}
+    (h : Identified hints i k) : Identified hints k i :=
+  ⟨h.1.symm, h.2.symm⟩
+
+theorem Identified.trans {G : Geometry} {hints : Hints G} {i k l : G.Col}
+    (h₁ : Identified hints i k) (h₂ : Identified hints k l) :
+    Identified hints i l :=
+  ⟨h₁.1.trans h₂.1, h₁.2.trans h₂.2⟩
+
+/-- Semantic sameness for fixed cells: the fixed values are identical. -/
+def SameFixed (C : AbstractCircuit F) (e₁ e₂ : C.G.Entry)
+    (h₁ : C.G.is_fixed e₁) (h₂ : C.G.is_fixed e₂) : Prop :=
+  C.f ⟨e₁, h₁⟩ = C.f ⟨e₂, h₂⟩
+
+/-- Semantic sameness for non-fixed cells: either equated by `≡` or
+    both unconstrained (where "unconstrained" uses the spec notion
+    including fixed columns). -/
+def SameNonFixed (C : AbstractCircuit F) (e₁ e₂ : C.G.Entry) : Prop :=
+  C.E e₁ e₂ ∨ (¬ C.constrained e₁ ∧ ¬ C.constrained e₂)
+
+/-- A constraint: the cell is not in a fixed column. -/
+def NotFixed (C : AbstractCircuit F) (e : C.G.Entry) : Prop :=
+  ¬ C.G.is_fixed e
+
+/-- Semantic sameness for two cells sharing a row.  Depends on whether
+    the columns are fixed or not. -/
+def SemanticallySame (C : AbstractCircuit F) (e₁ e₂ : C.G.Entry) : Prop :=
+  -- Both cells fixed with identical values
+  (∃ (h₁ : C.G.is_fixed e₁) (h₂ : C.G.is_fixed e₂), SameFixed C e₁ e₂ h₁ h₂) ∨
+  -- Both cells non-fixed and semantically identified
+  (NotFixed C e₁ ∧ NotFixed C e₂ ∧ SameNonFixed C e₁ e₂)
+
+/-- The `check_hints` predicate: for every pair of identified columns
+    and every row, the corresponding cells are semantically the same.
+
+    This is the hint well-formedness condition from issue #65. -/
+def check_hints (C : AbstractCircuit F) (hints : Hints C.G) : Prop :=
+  ∀ (i k : C.G.Col) (j : C.G.Row),
+    Identified hints i k → i ≠ k →
+    SemanticallySame C ⟨i, j⟩ ⟨k, j⟩
+
+/-! ## Sufficient conditions
+
+We exhibit progressively simpler sufficient conditions that imply
+`check_hints`.  These are useful for actually proving well-formedness
+in specific circuits. -/
+
+/-- A stricter sufficient condition: identified columns are never
+    identified to distinct cells.  Equivalently, the `h` and `e`
+    functions together are injective. -/
+def HintsInjective {G : Geometry} (hints : Hints G) : Prop :=
+  ∀ i k : G.Col, Identified hints i k → i = k
+
+/-- Injective hints are trivially well-formed (no identifications to check). -/
+theorem check_hints_of_injective {C : AbstractCircuit F} (hints : Hints C.G)
+    (h_inj : HintsInjective hints) : check_hints C hints := by
+  intro i k j h_id h_ne
+  exact absurd (h_inj i k h_id) h_ne
+
+/-- An intermediate condition: every pair of identified columns consists of
+    fully-equivalent columns, i.e., all cells in identified columns are
+    pairwise equivalent under `≡`. -/
+def EquivColumns (C : AbstractCircuit F) (hints : Hints C.G) : Prop :=
+  ∀ (i k : C.G.Col), Identified hints i k →
+    ∀ j : C.G.Row, C.E ⟨i, j⟩ ⟨k, j⟩
+
+/-- If cells in identified columns are equivalent and the columns are
+    non-fixed, then `check_hints` holds. -/
+theorem check_hints_of_equiv_columns {C : AbstractCircuit F}
+    {hints : Hints C.G}
+    (h_equiv : EquivColumns C hints)
+    (h_nonfixed : ∀ i k : C.G.Col, Identified hints i k → i ≠ k →
+      ∀ j : C.G.Row, NotFixed C ⟨i, j⟩ ∧ NotFixed C ⟨k, j⟩) :
+    check_hints C hints := by
+  intro i k j h_id h_ne
+  right
+  obtain ⟨hn_i, hn_k⟩ := h_nonfixed i k h_id h_ne j
+  exact ⟨hn_i, hn_k, Or.inl (h_equiv i k h_id j)⟩
+
+/-! ## Properties of well-formed hints
+
+Given `check_hints`, any two columns identified by the hints give
+cells that are either equivalent or (for fixed columns) have equal
+fixed values. -/
+
+/-- If hints are well-formed and two distinct columns are identified,
+    and both are non-fixed, then cells in the same row are either
+    equivalent or both unconstrained. -/
+theorem equivalent_or_unconstrained
+    {C : AbstractCircuit F} {hints : Hints C.G}
+    (h_wf : check_hints C hints)
+    {i k : C.G.Col} (h_id : Identified hints i k) (h_ne : i ≠ k)
+    (j : C.G.Row)
+    (hn_i_j : NotFixed C ⟨i, j⟩) :
+    C.E ⟨i, j⟩ ⟨k, j⟩ ∨ (¬ C.constrained ⟨i, j⟩ ∧ ¬ C.constrained ⟨k, j⟩) := by
+  have := h_wf i k j h_id h_ne
+  rcases this with ⟨h_i_fixed, _, _⟩ | ⟨_, _, hsame⟩
+  · exact absurd h_i_fixed hn_i_j
+  · exact hsame
+
+/-- If hints are well-formed and two distinct columns are identified,
+    and both are fixed, then cells in the same row have equal fixed values. -/
+theorem fixed_values_equal
+    {C : AbstractCircuit F} {hints : Hints C.G}
+    (h_wf : check_hints C hints)
+    {i k : C.G.Col} (h_id : Identified hints i k) (h_ne : i ≠ k)
+    (j : C.G.Row)
+    (h_i_fixed : C.G.is_fixed ⟨i, j⟩) (h_k_fixed : C.G.is_fixed ⟨k, j⟩) :
+    C.f ⟨⟨i, j⟩, h_i_fixed⟩ = C.f ⟨⟨k, j⟩, h_k_fixed⟩ := by
+  have := h_wf i k j h_id h_ne
+  rcases this with ⟨_, _, hsame⟩ | ⟨hn_i, _, _⟩
+  · exact hsame
+  · exact absurd h_i_fixed hn_i
+
+/-! ## Reflexivity: identity hints are well-formed
+
+If the hints are the identity (h_i = i.val, e_i = 0), then no two
+distinct columns are identified, so `check_hints` holds trivially. -/
+
+/-- Identity hints: map column `i` to concrete column `i` with offset 0. -/
+def identity_hints (G : Geometry) : Hints G where
+  h := fun i => i.val
+  e := fun _ => 0
+
+theorem identity_hints_injective (G : Geometry) :
+    HintsInjective (identity_hints G) := by
+  intro i k ⟨h_col, _⟩
+  ext; exact h_col
+
+theorem identity_hints_well_formed (C : AbstractCircuit F) :
+    check_hints C (identity_hints C.G) :=
+  check_hints_of_injective _ (identity_hints_injective C.G)
+
+end CheckHints

--- a/ZKProof/Plonkish/ValidHints.lean
+++ b/ZKProof/Plonkish/ValidHints.lean
@@ -1,0 +1,123 @@
+import Mathlib.Tactic
+
+import ZKProof.Plonkish.Defs
+import ZKProof.Plonkish.CheckHints
+
+/-!
+# Valid hints: bundled well-formedness
+
+Issue #52: either introduce a `check_hints` function (done in
+`CheckHints.lean` via `check_hints`), or edit hints to be a structure
+where all syntactically correct inputs lead to valid circuits.
+
+This file implements the second alternative: `ValidHints C` bundles
+the hint functions with a proof of well-formedness.  By construction,
+every inhabitant of `ValidHints C` yields a valid circuit — there is
+no way to construct one without the well-formedness proof.
+
+## Two formulations
+
+The repository now offers both alternatives:
+
+1. **Runtime check** (`CheckHints.lean`):
+   - `Hints G` is a plain pair of functions
+   - `check_hints C hints : Prop` is a separate predicate
+   - Well-formedness is a property to verify
+   - Suited for circuits where hints come from external sources
+
+2. **Type-level guarantee** (this file):
+   - `ValidHints C` bundles hints with a well-formedness proof
+   - Cannot construct a `ValidHints` without proving well-formedness
+   - Suited for circuits where hints are designed alongside proofs
+
+Both formulations are equivalent; we provide conversions between them.
+
+## On choosing "good" hints
+
+**Out of scope.**  Selecting hints that lead to *efficient* concrete
+circuits (few rows, few columns, compact layout) is an optimization
+problem orthogonal to well-formedness.  Any well-formed hints give a
+correct translation; different choices affect circuit size and
+prover performance.  Heuristics for good hint selection are a
+backend implementation concern, not part of the correctness
+specification.
+-/
+
+variable {F : Type} [Field F]
+
+namespace ValidHints
+open CheckHints
+
+/-- Valid hints for a specific circuit: the hint functions bundled
+    with a proof that they are well-formed.
+
+    By construction, `ValidHints C` is inhabited only by hints that
+    pass `check_hints`. -/
+structure _root_.ValidHints (C : AbstractCircuit F) where
+  /-- Target concrete column for each abstract column. -/
+  h : C.G.Col → ℕ
+  /-- Row offset for each abstract column. -/
+  e : C.G.Col → ℤ
+  /-- Well-formedness: identified columns have semantically identical cells. -/
+  well_formed : check_hints C ⟨h, e⟩
+
+/-- Forget the well-formedness proof to obtain plain hints. -/
+def toHints {C : AbstractCircuit F} (vh : _root_.ValidHints C) : Hints C.G where
+  h := vh.h
+  e := vh.e
+
+/-- Lift plain hints with a well-formedness proof to valid hints. -/
+def ofHints {C : AbstractCircuit F} (hints : Hints C.G)
+    (h_wf : check_hints C hints) : _root_.ValidHints C where
+  h := hints.h
+  e := hints.e
+  well_formed := h_wf
+
+/-- Round-trip: `toHints` after `ofHints` is identity. -/
+@[simp] theorem toHints_ofHints {C : AbstractCircuit F} (hints : Hints C.G)
+    (h_wf : check_hints C hints) :
+    toHints (ofHints hints h_wf) = hints := by
+  cases hints; rfl
+
+/-- Round-trip: `ofHints` after `toHints` is identity (on the hint data). -/
+@[simp] theorem ofHints_toHints {C : AbstractCircuit F} (vh : _root_.ValidHints C) :
+    ofHints (toHints vh) vh.well_formed = vh := by
+  cases vh; rfl
+
+/-- Valid hints always pass `check_hints` on their underlying data. -/
+theorem check_hints_ofValid {C : AbstractCircuit F} (vh : _root_.ValidHints C) :
+    check_hints C (toHints vh) :=
+  vh.well_formed
+
+/-! ## Constructing valid hints
+
+Sufficient conditions from `CheckHints.lean` transfer to constructors
+for `ValidHints`. -/
+
+/-- Construct valid hints from injective hint functions. -/
+def ofInjective {C : AbstractCircuit F} (h : C.G.Col → ℕ) (e : C.G.Col → ℤ)
+    (h_inj : HintsInjective ⟨h, e⟩) : _root_.ValidHints C where
+  h := h
+  e := e
+  well_formed := check_hints_of_injective _ h_inj
+
+/-- The identity hints are always valid. -/
+def identity (C : AbstractCircuit F) : _root_.ValidHints C :=
+  ofInjective (fun i => i.val) (fun _ => 0) (identity_hints_injective C.G)
+
+/-! ## Equivalence with the runtime-check formulation
+
+`ValidHints C` and `{hints : Hints C.G // check_hints C hints}`
+carry the same information.  We give the explicit equivalence. -/
+
+/-- `ValidHints C` is equivalent to the subtype of `Hints C.G` satisfying
+    `check_hints`.  This makes precise the claim that the two formulations
+    are interchangeable. -/
+def equivSubtype (C : AbstractCircuit F) :
+    _root_.ValidHints C ≃ { hints : Hints C.G // check_hints C hints } where
+  toFun vh := ⟨toHints vh, vh.well_formed⟩
+  invFun p := ofHints p.val p.property
+  left_inv vh := by cases vh; rfl
+  right_inv p := by cases p; rfl
+
+end ValidHints


### PR DESCRIPTION
Implements the second alternative from issue #52: ValidHints C bundles hint functions with a check_hints proof, so all inhabitants of the type are guaranteed well-formed by construction.

Provides conversions to/from plain Hints + check_hints predicate (the first alternative from #65), an equivSubtype witnessing the two formulations are interchangeable, and constructors including the identity hints example.

Module docs explain when to use each formulation and note that choosing efficient hints (compact layout, few columns) is an orthogonal optimization concern outside the correctness spec.

Closes #52 